### PR TITLE
fix: use string instead of enum to avoid conflicts of types

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -2,12 +2,6 @@ syntax = "proto3";
 
 package auth;
 
-enum Role {
-  ROLE_UNSPECIFIED = 0;
-  ROLE_USER = 1;
-  ROLE_FIDER = 2;
-}
-
 service AuthService {
   rpc Register (RegisterRequest) returns (RegisterResponse) {}
   rpc Login (LoginRequest) returns (LoginResponse) {}
@@ -19,7 +13,7 @@ service AuthService {
 message RegisterRequest {
   string email = 1;
   string password = 2;
-  Role role = 3;
+  string role = 3;
 }
 
 message RegisterResponse {
@@ -52,5 +46,5 @@ message ValidateResponse {
   int32 status = 1;
   repeated string errors = 2;
   optional string user_uuid = 3;
-  Role role = 4;
+  optional string role = 4;
 }


### PR DESCRIPTION
### Changes proposed in this pull request
- use string instead of enum to avoid conflicts of types

[FID-]
